### PR TITLE
improve get_rgb_representation

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,23 +1,11 @@
 
-
-
-
-
-pub fn get_rgb_representation(hex_string: String) -> Result<(u8, u8, u8), &'static str> {
-
-    let r1 = match u8::from_str_radix(&hex_string[1..3], 16) {
-        Ok(val) => val,
-        Err(_) => return Err("Malformatted"),
-    };
-    let r2 = match u8::from_str_radix(&hex_string[3..5], 16) {
-        Ok(val) => val,
-        Err(_) => return Err("Malformatted"),
-    };
-    let  r3 = match u8::from_str_radix(&hex_string[5..7], 16) {
-        Ok(val) => val,
-        Err(_) => return Err("Malformatted"),
-    };
-   
-    Ok((r1, r2, r3))
-    
+pub fn get_rgb_representation(hex: &str) -> Result<(u8, u8, u8), &'static str> {
+	if hex.len() < 8 { return Err("Malformatted"); }
+	if let (Ok(r1), Ok(r2), Ok(r3)) = (u8::from_str_radix(&hex[1..3], 16),
+								       u8::from_str_radix(&hex[3..5], 16),
+								       u8::from_str_radix(&hex[5..7], 16)) {
+		Ok((r1, r2, r3))
+	} else {
+		Err("Malformatted")
+	}    
 }


### PR DESCRIPTION
This should be more readable, no longer requires an owned string and no longer panics on too short strings, returns `Err` instead.